### PR TITLE
Add usescases

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This is a repo to explore, and hopefully define a way to maintain aspect ratio
 # Usecases
 ... see issues, we should end up with a few here ...
 
+- Prevent content pushing from layout reflows by implementing aspect-ratio sized box [demo](http://daverupert.com/2015/12/intrinsic-placeholders-with-picture/)
+- Prevent content pushing when `picture` aspect-ratio changes [demo](http://daverupert.com/2012/04/uncle-daves-ol-padded-box/)
+
 # Potential solution
 Jonathan Kingston already has a decent proposal here for it to work in CSS: https://jonathankingston.github.io/logical-sizing-properties/#propdef-aspect-ratio
 


### PR DESCRIPTION
Just a couple of usecases I've uncovered over the years.
- Prevent content pushing when initial image loads
- Prevent content pushing when `<picture>` swaps `<source>` (this one is pre-picture tho, uses background image. same concept tho)
